### PR TITLE
Use correct commitUrl when linking to commit

### DIFF
--- a/lib/scripts/hubinfo.js
+++ b/lib/scripts/hubinfo.js
@@ -89,7 +89,7 @@
             .end()
           .find('.repo-commit-message')
             .html(lastCommit.commit.message)
-            .attr('href', 'http://github.com'+lastCommit.url)
+            .attr('href', lastCommit.url)
             .end()
           .find('.repo-commit-date span')
             .html(relativeDate(lastCommit.commit.committer.date))


### PR DESCRIPTION
The URL to be used for the latest commit href was being prepended with
"http://github.com" manually, which is not necessary.

Signed-off-by: Johannes Gilger heipei@hackvalue.de

---

Sorry, the Makefile did not work for me. I did install masher and stylus using npm, and was able to call the command, but the resulting files in dist/ all turned up empty. Maybe another bug?
