### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#HubInfo
+# HubInfo
 
 [HubInfo](http://projects.jga.me/hubinfo/) is a jQuery plugin to show information about your GitHub repo. 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,9 +30,9 @@ Out of the box, the twitter share widget isn't there, but if you want to add it,
 		!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");
 	});
 
-##History
+## History
 
 [View](https://raw.github.com/jgallen23/hubinfo/master/history.md)
 
-##Contributors
+## Contributors
 - Greg Allen ([@jgaui](http://twitter.com/jgaui)) [jga.me](http://jga.me)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
